### PR TITLE
Botcheck limits

### DIFF
--- a/Extras/Botcheck/botcheck
+++ b/Extras/Botcheck/botcheck
@@ -32,7 +32,7 @@ bbsPort="$3"
 # clients.
 echo -e -n "Welcome to botcheck!\r\n\r\n"
 echo -e -n "Prove you're not a bot by entering \"$expectedAnswer\": "
-answer="$(readline.py --timeout 30)"
+answer="$(readline.py --timeout 30 --numChars $[${#expectedAnswer} * 2])"
 echo -e -n "\r\n"
 if [[ "$answer" == "$expectedAnswer" ]]; then
     nc "$bbsHost" "$bbsPort"

--- a/Extras/Botcheck/readline.py
+++ b/Extras/Botcheck/readline.py
@@ -13,18 +13,21 @@ parser = optparse.OptionParser(
     usage = "Usage: %prog [options]",
     description = "Read a line of text and print it",
     option_list = [
-        optparse.make_option("-t", "--timeout", type = "int", help = "Timeout to read a line in seconds")])
+        optparse.make_option("-t", "--timeout", type = "int", help = "Timeout to read a line in seconds"),
+        optparse.make_option("-n", "--numChars", type = "int", help = "Maximum number of characters to read")
+    ])
 
 options, args = parser.parse_args()
 
 timeout = timedelta(seconds = options.timeout) if options.timeout else timedelta.max
+numChars = options.numChars if options.numChars else sys.maxsize
 returnValue = 0
 chars = []
 
 unbufferedStdin = os.fdopen(sys.stdin.fileno(), "rb", 0)
 
 startDatetime = datetime.now()
-while True:
+while len(chars) < numChars:
     readable, writeable, exceptions = select.select([unbufferedStdin], [], [], 1)
     if unbufferedStdin in readable:
         timeoutCount = 0


### PR DESCRIPTION
Limit how much memory the python process can use in case of malicious clients. First by fixing broken timeout logic and secondly by adding a limit on how many characters to read.