### PR TITLE
 Avoid slink command too long when using normal shell.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ NoDebug
 nikom_pragmas.h
 Include/CatalogDefaults.h
 /NiKomDev.lha
+Nodes/objects.slink
 Tools/SetNodeState/SetNodeState
 Tools/CryptPasswords/CryptPasswords
 Tools/NiKomFido/NiKomFido

--- a/NiKomLib/Funcs.h
+++ b/NiKomLib/Funcs.h
@@ -10,9 +10,9 @@
 #include <dos/dos.h>
 #endif
 
-/* Funktionsprototyper */
+/* Function prototypes */
 
-/* De i librariet */
+/* Those in the library */
 void __saveds __asm LIBMatrix2NiKom(register __a6 struct NiKomBase *);
 LONG __saveds __asm LIBRexxEntry(register __a0 struct RexxMsg *,register __a6 struct NiKomBase *);
 void __saveds __asm LIBLockNiKomBase(register __a6 struct NiKomBase *);
@@ -54,7 +54,7 @@ int __saveds __asm LIBCreateUser(register __d0 LONG, register __a0 struct TagIte
 int __saveds __asm LIBNiKParse(register __a0 char *string, register __d0 char subject, register __a6 struct NiKomBase *NiKomBase);
 int __saveds __asm LIBSysInfo(register __a0 char *subject, register __a6 struct NiKomBase *NiKomBase);
 
-/* Andra trevliga små funktioner */
+/* Other useful little functions */
 
 /* Matrix.c */
 int sprattmatchar(char *,char *);
@@ -75,7 +75,7 @@ int sethwm(char *,int, char);
 /* Echo.c */
 struct Mote *getmotpek(int, struct System *);
 
-/* terminal.c */
+/* Terminal.c */
 UBYTE convnokludge(UBYTE);
 
 /* ServerComm.c */

--- a/Nodes/makefile
+++ b/Nodes/makefile
@@ -24,18 +24,22 @@ NoDebug/$(CPU): NoDebug
   -makedir NoDebug/$(CPU)
 
 clean:
+  -delete objects.slink
   -delete \#?.o
   -delete Debug NoDebug all
 
-NiKomCon: Debug/$(CPU) NoDebug/$(CPU) $(OBJS) $(CONOBJS)
-  slink FROM lib:c.o $(CONOBJS) $(OBJS) \
+objects.slink:
+  echo $(OBJS) >objects.slink
+
+NiKomCon: Debug/$(CPU) NoDebug/$(CPU) $(OBJS) $(CONOBJS) objects.slink
+  slink FROM lib:c.o $(CONOBJS) WITH objects.slink \
         TO Debug/$(CPU)/NiKomCon \
         LIB lib:sc.lib+lib:amiga.lib+/UtilLib/Debug/$(CPU)/nikomutils.lib \
         NOICONS
   slink Debug/$(CPU)/NiKomCon TO NoDebug/$(CPU)/NiKomCon NODEBUG NOICONS
 
-NiKomSer: Debug/$(CPU) NoDebug/$(CPU) $(OBJS) $(SEROBJS)
-  slink FROM lib:c.o $(SEROBJS) $(OBJS) \
+NiKomSer: Debug/$(CPU) NoDebug/$(CPU) $(OBJS) $(SEROBJS) objects.slink
+  slink FROM lib:c.o $(SEROBJS) WITH objects.slink \
         TO Debug/$(CPU)/NiKomSer \
         LIB lib:sc.lib+lib:amiga.lib+/UtilLib/Debug/$(CPU)/nikomutils.lib \
         NOICONS VERBOSE


### PR DESCRIPTION
 Link common objects into nikomnode1.lib and nikomnode2.lib before linking everything together, to prevent the command line from becoming too long for AmigaShell.
