### PR TITLE
Initial UTF-8 support for NiKom

### DIFF
--- a/Catalogs/NiKom.cd
+++ b/Catalogs/NiKom.cd
@@ -335,7 +335,7 @@ SIS-7 (Swedish 7 bit encoding)
 MSG_CHRS_NEW (511//)
 New character set
 MSG_CHRS_BAD (512//)
-Bad character set. Choice must be between 1 and 4.
+Bad character set. Choice must be between %u and %u.
 MSG_CHRS_UTF8 (513//)
 UTF-8
 ;

--- a/Catalogs/NiKom.cd
+++ b/Catalogs/NiKom.cd
@@ -336,6 +336,8 @@ MSG_CHRS_NEW (511//)
 New character set
 MSG_CHRS_BAD (512//)
 Bad character set. Choice must be between 1 and 4.
+MSG_CHRS_UTF8 (513//)
+UTF-8
 ;
 MSG_EDIT_LINE_HELP1 (600//)
 Press Ctrl-Z on an empty line to save the text.

--- a/Catalogs/NiKom_svenska.ct
+++ b/Catalogs/NiKom_svenska.ct
@@ -339,7 +339,7 @@ SIS-7 (Svensk 7-bit, måsvingar)
 MSG_CHRS_NEW
 Nytt teckenset
 MSG_CHRS_BAD
-Felaktig teckenuppsättning, ska vara mellan 1 och 4.
+Felaktig teckenuppsättning, ska vara mellan %u och %u.
 MSG_CHRS_UTF8
 UTF-8
 ;

--- a/Catalogs/NiKom_svenska.ct
+++ b/Catalogs/NiKom_svenska.ct
@@ -340,6 +340,8 @@ MSG_CHRS_NEW
 Nytt teckenset
 MSG_CHRS_BAD
 Felaktig teckenuppsättning, ska vara mellan 1 och 4.
+MSG_CHRS_UTF8
+UTF-8
 ;
 MSG_EDIT_LINE_HELP1
 Tryck Ctrl-Z på en tom rad för att spara texten.

--- a/Include/NiKomLib.h
+++ b/Include/NiKomLib.h
@@ -73,6 +73,7 @@ struct FidoLine
 #define CHRS_SIS7     4
 #define CHRS_MAC      8
 #define CHRS_CP850   16
+#define CHRS_UTF8    32
 
 /* Vilka lägen en nod kan befinna sig i */
 #define NIKSTATE_RELOGIN    1   /* Användaren ska göra en ny inloggning */

--- a/Include/NiKomStr.h
+++ b/Include/NiKomStr.h
@@ -165,9 +165,6 @@
 #define ITER_EL(var, list, nodeField, type) for(var = (type)list.mlh_Head; var->nodeField.mln_Succ; var = (type) var->nodeField.mln_Succ)
 #define ITER_EL_R(var, list, nodeField, type) for(var = (type)list.mlh_TailPred; var->nodeField.mln_Pred; var = (type) var->nodeField.mln_Pred)
 
-/* Flaggor till putstring() */
-#define PS_NOCONV 1
-
 struct Statuscfg {
    char skriv,texter,brev,medmoten,radmoten,sestatus,anv,chgstatus,
       bytarea,radarea,filer,laddaner,crashmail, grupper;

--- a/Include/nikom_protos.h
+++ b/Include/nikom_protos.h
@@ -32,6 +32,8 @@ int IsMemberConf(int, int, struct User *);
 char *GetBuildTime(void);
 void ConvChrsToAmiga(char *, int, int);
 void ConvChrsFromAmiga(char *, int, int);
+int ConvMBChrsToAmiga(char *, char *, int, int);
+int ConvMBChrsFromAmiga(char *, char *, int, int);
 void StripAnsiSequences(char *);
 int SetNodeState(int, int);
 int SendNodeMessage(int, int, char *);

--- a/NiKomLib/Funcs.h
+++ b/NiKomLib/Funcs.h
@@ -42,6 +42,10 @@ void __saveds __asm LIBConvChrsToAmiga(register __a0 char *, register __d0 int,
 void __saveds __asm LIBConvChrsFromAmiga(register __a0 char *, register __d0 int,
 	register __d1 int, register __a6 struct NiKomBase *);
 void __saveds __asm LIBStripAnsiSequences(register __a0 char *, register __a6 struct NiKomBase *);
+int __saveds __asm LIBConvMBChrsToAmiga(register __a0 char *, register __a1 char *,
+	register __d0 int, register __d1 int, register __a6 struct NiKomBase *);
+int __saveds __asm LIBConvMBChrsFromAmiga(register __a0 char *, register __a1 char *,
+	register __d0 int, register __d1 int, register __a6 struct NiKomBase *);
 int __saveds __asm LIBSetNodeState(register __d0 int, register __d1 int);
 int __saveds __asm LIBSendNodeMessage(register __d0 int, register __d1 int, register __a0 char *, register __a6 struct NiKomBase *);
 NiKHash * __saveds __asm LIBNewNiKHash(register __d0 int);

--- a/NiKomLib/nikom.fd
+++ b/NiKomLib/nikom.fd
@@ -52,4 +52,6 @@ FindNextTextInConference(searchStart,conf)(D0,D1)
 FindPrevTextInConference(searchStart,conf)(D0,D1)
 WriteConferenceTexts()
 DeleteConferenceTexts(numberOfTexts)(D0)
+ConvMBChrsToAmiga(dst,src,len,chrs)(A0,A1,D0,D1)
+ConvMBChrsFromAmiga(dst,src,len,chrs)(A0,A1,D0,D1)
 ##end

--- a/Nodes/CharacterSets.c
+++ b/Nodes/CharacterSets.c
@@ -46,6 +46,9 @@ int AskUserForCharacterSet(int forceChoice, int showExamples) {
   Servermem->inne[nodnr].chrset = CHRS_SIS7;
   SendString("%c 4: %-45s %s\n\r",
              chrsetbup == CHRS_SIS7 ? '*' : ' ', CATSTR(MSG_CHRS_SIS7), example);
+  Servermem->inne[nodnr].chrset = CHRS_UTF8;
+  SendString("%c 5: %-45s %s\n\r",
+             chrsetbup == CHRS_UTF8 ? '*' : ' ', CATSTR(MSG_CHRS_UTF8), example);
 
   Servermem->inne[nodnr].chrset = chrsetbup;
   SendString("\n\r%s ", CATSTR(MSG_COMMON_CHOICE));
@@ -69,6 +72,10 @@ int AskUserForCharacterSet(int forceChoice, int showExamples) {
     case '4' :
       Servermem->inne[nodnr].chrset = CHRS_SIS7;
       SendString("%s\n\r", CATSTR(MSG_CHRS_SIS7));
+      return 0;
+    case '5' :
+      Servermem->inne[nodnr].chrset = CHRS_UTF8;
+      SendString("%s\n\r", CATSTR(MSG_CHRS_UTF8));
       return 0;
     case GETCHAR_RETURN :
       if(!forceChoice) {

--- a/Nodes/NiKFuncs5.c
+++ b/Nodes/NiKFuncs5.c
@@ -117,7 +117,7 @@ void bytteckenset(void) {
       }
       break;
     default :
-      SendString("\n\n\r%s\n\r", CATSTR(MSG_CHRS_BAD));
+      SendStringCat("\n\n\r%s\n\r", CATSTR(MSG_CHRS_BAD), 1, 5);
       return;
     }
   }

--- a/Nodes/NiKFuncs5.c
+++ b/Nodes/NiKFuncs5.c
@@ -104,6 +104,10 @@ void bytteckenset(void) {
       Servermem->inne[nodnr].chrset = CHRS_SIS7;
       SendString("\n\n\r%s: %s\n\r", CATSTR(MSG_CHRS_NEW), CATSTR(MSG_CHRS_SIS7));
       return;
+    case '5' :
+      Servermem->inne[nodnr].chrset = CHRS_UTF8;
+      SendString("\n\n\r%s: %s\n\r", CATSTR(MSG_CHRS_NEW), CATSTR(MSG_CHRS_UTF8));
+      return;
     case '-':
       if(argument[1] == 'e' || argument[1] == 'E') {
         showExample = TRUE;

--- a/Nodes/SerialIO.c
+++ b/Nodes/SerialIO.c
@@ -437,13 +437,8 @@ void putstring(char *pekare,int size, long flags) {
 	char serpekare[400];
 	int bytes;
 
-	if((flags & PS_NOCONV)) {
-	  strncpy(serpekare,pekare,199);
-	  serpekare[199] = 0;
-	  bytes = strlen(serpekare);
-	} else {
-	  bytes = ConvMBChrsFromAmiga(serpekare,pekare,199,Servermem->inne[nodnr].chrset);
-	}
+	bytes = ConvMBChrsFromAmiga(serpekare, pekare, 199,
+				    Servermem->inne[nodnr].chrset);
 	serwritereq->IOSer.io_Command=CMD_WRITE;
 	serwritereq->IOSer.io_Data=serpekare;
 	serwritereq->IOSer.io_Length=bytes;
@@ -461,13 +456,8 @@ void serputstring(char *pekare,int size, long flags)
 	char serpekare[400];
 	int bytes;
 
-	if((flags & PS_NOCONV)) {
-	  strncpy(serpekare,pekare,199);
-	  serpekare[199] = 0;
-	  bytes = strlen(serpekare);
-	} else {
-	  bytes = ConvMBChrsFromAmiga(serpekare,pekare,199,Servermem->inne[nodnr].chrset);
-	}
+	bytes = ConvMBChrsFromAmiga(serpekare, pekare, 199,
+				    Servermem->inne[nodnr].chrset);
 	serwritereq->IOSer.io_Command=CMD_WRITE;
 	serwritereq->IOSer.io_Data=serpekare;
 	serwritereq->IOSer.io_Length=bytes;

--- a/Nodes/SerialIO.c
+++ b/Nodes/SerialIO.c
@@ -284,6 +284,8 @@ char gettekn(void) {
     serreadsig = 1L << serreadport->mp_SigBit,
     inactivesig=1L << inactiveport->mp_SigBit,
     nikomnodesig = 1L << nikomnodeport->mp_SigBit;
+  char serbuf[8];
+  int seridx;
   char ch = '\0', tmp[51];
 
   if(ImmediateLogout()) {
@@ -298,6 +300,7 @@ char gettekn(void) {
     return ch;
   }
 
+  seridx = 0;
   while(!ch) {
     signals = Wait(conreadsig | windsig | serreadsig | inactivesig | nikomnodesig
                    | SIGBREAKF_CTRL_C);
@@ -306,8 +309,14 @@ char gettekn(void) {
       UpdateInactive();
     }
     if((signals & serreadsig) && CheckIO((struct IORequest *)serreadreq)) {
-      ch = sergettkn();
-      ConvChrsToAmiga(&ch,1,Servermem->inne[nodnr].chrset);
+      int conv;
+      serbuf[seridx] = sergettkn();
+      conv = ConvMBChrsToAmiga(&ch,serbuf,seridx+1,
+                               Servermem->inne[nodnr].chrset);
+      if (conv < 0) {
+        /* Need more bytes, continue reading. */
+        ++seridx;
+      }
       UpdateInactive();
       QueryCarrierDropped();
     }
@@ -370,16 +379,16 @@ char sergettkn(void) {
 
 void eka(char tecken) {
 	int err;
-	char sertkn;
+	char sertkn[2];
+	int bytes;
 	conwritereq->io_Command=CMD_WRITE;
 	conwritereq->io_Data=(APTR)&tecken;
 	conwritereq->io_Length=1;
 	if(DoIO((struct IORequest *)conwritereq)) printf("DoIO i eka() (1)\n");
-	sertkn=tecken;
-	ConvChrsFromAmiga(&sertkn,1,Servermem->inne[nodnr].chrset);
+	bytes = ConvMBChrsFromAmiga(sertkn,&tecken,1,Servermem->inne[nodnr].chrset);
 	serwritereq->IOSer.io_Command=CMD_WRITE;
-	serwritereq->IOSer.io_Data=(APTR)&sertkn;
-	serwritereq->IOSer.io_Length=1;
+	serwritereq->IOSer.io_Data=(APTR)sertkn;
+	serwritereq->IOSer.io_Length=bytes;
 	if(err=DoIO((struct IORequest *)serwritereq)) writesererr(err);
 
 	if(tecken == '\n')
@@ -389,12 +398,12 @@ void eka(char tecken) {
 void sereka(char tecken)
 {
 	int err;
-	char sertkn;
-	sertkn=tecken;
-	ConvChrsFromAmiga(&sertkn,1,Servermem->inne[nodnr].chrset);
+	char sertkn[2];
+	int bytes;
+	bytes = ConvMBChrsFromAmiga(sertkn,&tecken,1,Servermem->inne[nodnr].chrset);
 	serwritereq->IOSer.io_Command=CMD_WRITE;
-	serwritereq->IOSer.io_Data=(APTR)&sertkn;
-	serwritereq->IOSer.io_Length=1;
+	serwritereq->IOSer.io_Data=(APTR)sertkn;
+	serwritereq->IOSer.io_Length=bytes;
 	if(err=DoIO((struct IORequest *)serwritereq)) writesererr(err);
 
 	if(tecken == '\n')
@@ -425,14 +434,19 @@ void serreqtkn(void) {
 
 void putstring(char *pekare,int size, long flags) {
 	int err;
-	char serpekare[200];
+	char serpekare[400];
+	int bytes;
 
-	strncpy(serpekare,pekare,199);
-	serpekare[199] = 0;
-	if(!(flags & PS_NOCONV)) ConvChrsFromAmiga(serpekare,0,Servermem->inne[nodnr].chrset);
+	if((flags & PS_NOCONV)) {
+	  strncpy(serpekare,pekare,199);
+	  serpekare[199] = 0;
+	  bytes = strlen(serpekare);
+	} else {
+	  bytes = ConvMBChrsFromAmiga(serpekare,pekare,199,Servermem->inne[nodnr].chrset);
+	}
 	serwritereq->IOSer.io_Command=CMD_WRITE;
 	serwritereq->IOSer.io_Data=serpekare;
-	serwritereq->IOSer.io_Length=strlen(serpekare);
+	serwritereq->IOSer.io_Length=bytes;
 	SendIO((struct IORequest *)serwritereq);
 	conwritereq->io_Command=CMD_WRITE;
 	conwritereq->io_Data=(APTR)pekare;
@@ -444,14 +458,19 @@ void putstring(char *pekare,int size, long flags) {
 
 void serputstring(char *pekare,int size, long flags)
 {
-	char serpekare[200];
+	char serpekare[400];
+	int bytes;
 
-	strncpy(serpekare,pekare,199);
-	serpekare[199] = 0;
-	if(!(flags & PS_NOCONV)) ConvChrsFromAmiga(serpekare,0,Servermem->inne[nodnr].chrset);
+	if((flags & PS_NOCONV)) {
+	  strncpy(serpekare,pekare,199);
+	  serpekare[199] = 0;
+	  bytes = strlen(serpekare);
+	} else {
+	  bytes = ConvMBChrsFromAmiga(serpekare,pekare,199,Servermem->inne[nodnr].chrset);
+	}
 	serwritereq->IOSer.io_Command=CMD_WRITE;
 	serwritereq->IOSer.io_Data=serpekare;
-	serwritereq->IOSer.io_Length=strlen(serpekare);
+	serwritereq->IOSer.io_Length=bytes;
 	DoIO((struct IORequest *)serwritereq);
 }
 
@@ -667,8 +686,8 @@ int checkcharbuffer(void)
 
 int puttekn(char *pekare,int size)
 {
-	int aborted=FALSE, x1, x2, consize, sersize, nyrad;
-	char serpekare[1200],localconstring[1200];
+	int aborted=FALSE, x1, x2, consize, sersize, nyrad, bytes;
+	char serpekare[2400],localconstring[1200];
 	char serbuf[1200], conbuf[1200], *concurpek, *sercurpek, *constartpek, *serstartpek;
 	char conready, serready, conlineready, serlineready;
 
@@ -686,16 +705,19 @@ int puttekn(char *pekare,int size)
 	strncpy(localconstring,pekare,1199);
 	localconstring[1199]=0;
 	if(Servermem->cfg.cfgflags & NICFG_LOCALCOLOURS) {
-		strncpy(serpekare,pekare,1199);
+		bytes=ConvMBChrsFromAmiga(serpekare,pekare,1199,Servermem->inne[nodnr].chrset);
+		serpekare[bytes] = '\0';
 		if(!(Servermem->inne[nodnr].flaggor & ANSICOLOURS)) StripAnsiSequences(serpekare);
 	} else {
 		StripAnsiSequences(localconstring);
-		if(Servermem->inne[nodnr].flaggor & ANSICOLOURS) strncpy(serpekare,pekare,1199);
-		else strncpy(serpekare,localconstring,1199);
+		if(Servermem->inne[nodnr].flaggor & ANSICOLOURS) {
+			bytes=ConvMBChrsFromAmiga(serpekare,pekare,1199,Servermem->inne[nodnr].chrset);
+			serpekare[bytes] = '\0';
+		} else  {
+			bytes=ConvMBChrsFromAmiga(serpekare,localconstring,1199,Servermem->inne[nodnr].chrset);
+			serpekare[bytes] = '\0';
+		}
 	}
-	serpekare[1199]=0;
-
-	ConvChrsFromAmiga(serpekare,0,Servermem->inne[nodnr].chrset);
 
 	concurpek = constartpek = &localconstring[0];
 	sercurpek = serstartpek = &serpekare[0];

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,9 @@
 ---------------------------------------------------------------------------
                          NiKom v2.3.0, 2017-xx-yy
 ---------------------------------------------------------------------------
+NiKom now supports UTF-8 terminals. Users can select UTF-8 as their
+character set.
+
 NiKom now supports multiple languages. Initially the two available
 langauges are English and Swedish which are selected for each induvidual
 user. The default language is English which means that when 2.3 is


### PR DESCRIPTION
Adds nikom.library support for converting to and from UTF-8, and support for choosing UTF-8 as the terminal character set.  (GitHub issue #77)