### PR TITLE
Create xinetd_service

### DIFF
--- a/Extras/Botcheck/xinetd_service
+++ b/Extras/Botcheck/xinetd_service
@@ -1,0 +1,10 @@
+service mybbs
+{
+    flags       = NAMEINARGS
+    socket_type = stream
+    protocol    = tcp
+    wait        = no
+    user        = nobody
+    server      = /<path-to>/botcheck
+    server_args = botcheck <code-in-botcheck> <ip-address-or-hostname-of-bbs> <bbs port>
+}


### PR DESCRIPTION
Xinetd service för Botcheck.  Works in CentOS 7 (placed in /etc/xinetd.d/)